### PR TITLE
ntlm authanticaiton added.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginName=cyberark
 # The apiVersion property is used to set the @API_VERSION@ variable in the plugin.xml file and is used in
 # combination with the pluginVersion property to set the @RELEASE_VERSION@ variable in the info.xml file (apiVersion.pluginVersion).
 # It is also used in the distributable .zip file name as shown previously.
-apiVersion=7
+apiVersion=8
 
 # The pluginVersion property is used to set the specific build of the version, which is used in
 # combination with the apiVersion property to set the @RELEASE_VERSION@ variable in the info.xml file (apiVersion.pluginVersion).

--- a/src/main/groovy/com/urbancode/air/plugin/cyberark/AIMRestClient.groovy
+++ b/src/main/groovy/com/urbancode/air/plugin/cyberark/AIMRestClient.groovy
@@ -28,7 +28,11 @@ class AIMRestClient {
         boolean trustAllCerts,
         String keyType,
         String keyStore,
-        String keyPass)
+        String keyPass,
+		boolean isNtlm,
+		String domain,
+		String username,
+		Stirng pass)
     {
         if (!serverUrl.substring(0, 7).equalsIgnoreCase("http://") && !serverUrl.substring(0, 8).equalsIgnoreCase("https://")){
             println("[Error] An HTTP protocol (http:// or https://) must be prepended to server URL: ${serverUrl}")
@@ -66,6 +70,13 @@ class AIMRestClient {
 
             clientBuilder.setKeyManagers(kmFactory.getKeyManagers())
         }
+        
+        if(!StringUtils.isEmpty(username) && !StringUtils.isEmpty(pass)){
+			clientBuilder.setNtlm(isNtlm);
+			clientBuilder.setDomain(domain);
+			clientBuilder.setUsername(username);
+			clientBuilder.setPassword(pass);
+		}
 
         client = clientBuilder.buildClient()
     }

--- a/src/main/zip/info.xml
+++ b/src/main/zip/info.xml
@@ -27,5 +27,8 @@
     <release-note plugin-version="7">
         RFE 128463 - Property to enable SSL debugging.
     </release-note>
+    <release-note plugin-version="8">
+        NTLM authanticaiton added.
+    </release-note>
   </release-notes>
 </pluginInfo>

--- a/src/main/zip/plugin.xml
+++ b/src/main/zip/plugin.xml
@@ -97,6 +97,27 @@
                      hidden="true"
                      default-value="${p?:process.id}"/>
       </property>
+      
+      <property name="isNtlm">
+        <property-ui type="checkBox"
+                     label="Activate NTLM Authantication"
+                     description="Activate NTLM Authantication."/>
+      </property>
+	  <property name="domain">
+        <property-ui type="textBox"
+                     label="Domain of NTLM Authantication"
+                     description="The domain of the ntlm's authantication."/>
+      </property>
+      <property name="username">
+        <property-ui type="textBox"
+                     label="Username of NTLM Authantication"
+                     description="The username of the ntlm's authantication."/>
+      </property>
+      <property name="pass">
+        <property-ui type="secureBox"
+                     label="Password of NTLM User"
+                     description="The password of the ntlm's user."/>
+      </property>
     </properties>
     <post-processing><![CDATA[
         if (properties.get("exitCode") != 0) {

--- a/src/main/zip/requestPassword.groovy
+++ b/src/main/zip/requestPassword.groovy
@@ -19,12 +19,17 @@ String keyType = props['keyType']
 boolean trustCerts = Boolean.valueOf(props['trustCerts'])
 String jsseDebugLevel = props['jsseDebugLevel']?.trim()
 
+String isNtlm = Boolean.valueOf(props['isNtlm'])
+String domain = props['domain']
+String username = props['username']
+String pass = props['pass']
+
 /* Configure JSSE debugging if specified */
 if (jsseDebugLevel) {
     System.setProperty("javax.net.debug", jsseDebugLevel)
 }
 
-AIMRestClient aimClient = new AIMRestClient(serverUrl, trustCerts, keyType, keyStore, keyPass)
+AIMRestClient aimClient = new AIMRestClient(serverUrl, trustCerts, keyType, keyStore, keyPass, isNtlm, domain, username, pass)
 UCDRestHelper ucdHelper = new UCDRestHelper()
 
 try {

--- a/src/main/zip/upgrade.xml
+++ b/src/main/zip/upgrade.xml
@@ -34,4 +34,14 @@
       </migrate-properties>
     </migrate-command>
   </migrate>
+  <migrate to-version="8">
+    <migrate-command name="Get Password from CCP (Web Service) With NTLM">
+      <migrate-properties>
+        <migrate-property name="isNtlm" default="" />
+        <migrate-property name="domain" default="" />
+        <migrate-property name="username" default="" />
+        <migrate-property name="pass" default="" />
+      </migrate-properties>
+    </migrate-command>
+  </migrate>
 </plugin-upgrade>


### PR DESCRIPTION
With that modification plugin will be support NTLM authentication but IBM should modify "_uDeployRestClient.jar_" which include "_CloseableHttpClientBuilder.class_". Without modify that class, current modification fail.

CloseableHttpClientBuilder.class
```

// new fields
private boolean isNtlm = false;
private String domain = null;

// ntlm support should be added to the line 205
if(isNtlm){
	Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create().register(AuthSchemes.NTLM, new NTLMSchemeFactory()).build();
	basicCredentialsProvider.setCredentials(AuthScope.ANY, new NTCredentials(this.username, this.password, "", this.domain));
	
	clientBuilder.setDefaultAuthSchemeRegistry(authSchemeRegistry);
}else{
	UsernamePasswordCredentials usernamePasswordCredentials = new UsernamePasswordCredentials(this.username, this.password);
	basicCredentialsProvider.setCredentials(AuthScope.ANY, (Credentials)usernamePasswordCredentials);
}
```

